### PR TITLE
Fix Type of Amount fields in payment reponse

### DIFF
--- a/payments.go
+++ b/payments.go
@@ -1,5 +1,7 @@
 package flutterwave
 
+import "encoding/json"
+
 // GetPaymentLinkRequest is data needed to create a payment link
 type GetPaymentLinkRequest struct {
 	TransactionReference string                       `json:"tx_ref"`
@@ -74,25 +76,25 @@ type InitiateMobileMoneyFrancoResponse struct {
 	Status  string `json:"status"`  // Status of the charge request
 	Message string `json:"message"` // Message related to the charge request
 	Data    struct {
-		ID                int    `json:"id"`
-		TxRef             string `json:"tx_ref"`
-		FlwRef            string `json:"flw_ref"`
-		OrderID           string `json:"order_id"`
-		DeviceFingerprint string `json:"device_fingerprint"`
-		Amount            uint32 `json:"amount"`
-		ChargedAmount     uint32 `json:"charged_amount"`
-		AppFee            uint32 `json:"app_fee"`
-		MerchantFee       int    `json:"merchant_fee"`
-		AuthModel         string `json:"auth_model"`
-		Currency          string `json:"currency"`
-		IP                string `json:"ip"`
-		Narration         string `json:"narration"`
-		Status            string `json:"status"`
-		PaymentType       string `json:"payment_type"`
-		FraudStatus       string `json:"fraud_status"`
-		ChargeType        string `json:"charge_type"`
-		CreatedAt         string `json:"created_at"`
-		AccountID         int    `json:"account_id"`
+		ID                int         `json:"id"`
+		TxRef             string      `json:"tx_ref"`
+		FlwRef            string      `json:"flw_ref"`
+		OrderID           string      `json:"order_id"`
+		DeviceFingerprint string      `json:"device_fingerprint"`
+		Amount            json.Number `json:"amount"`
+		ChargedAmount     json.Number `json:"charged_amount"`
+		AppFee            json.Number `json:"app_fee"`
+		MerchantFee       json.Number `json:"merchant_fee"`
+		AuthModel         string      `json:"auth_model"`
+		Currency          string      `json:"currency"`
+		IP                string      `json:"ip"`
+		Narration         string      `json:"narration"`
+		Status            string      `json:"status"`
+		PaymentType       string      `json:"payment_type"`
+		FraudStatus       string      `json:"fraud_status"`
+		ChargeType        string      `json:"charge_type"`
+		CreatedAt         string      `json:"created_at"`
+		AccountID         int         `json:"account_id"`
 		Customer          struct {
 			ID          int    `json:"id"`
 			PhoneNumber string `json:"phone_number"`

--- a/payments_service_test.go
+++ b/payments_service_test.go
@@ -24,7 +24,7 @@ func Test_paymentsService_InitiateMobileMoneyFranco_success(t *testing.T) {
 
 	// Act
 	data, response, err := client.Payments.InitiateMobileMoneyFranco(ctx, &InitiateMobileMoneyFrancoRequest{
-		Amount:         10_000,
+		Amount:         "10000",
 		Currency:       "XAF",
 		PhoneNumber:    "+237678787878",
 		Email:          "alice@example.com",
@@ -49,8 +49,8 @@ func Test_paymentsService_InitiateMobileMoneyFranco_success(t *testing.T) {
 	expectedResp.Data.FlwRef = "FLW714021585320891879"
 	expectedResp.Data.OrderID = "USS_URG_893982923s2323"
 	expectedResp.Data.DeviceFingerprint = "62wd23423rq324323qew1"
-	expectedResp.Data.Amount = 10_000
-	expectedResp.Data.ChargedAmount = 10_000
+	expectedResp.Data.Amount = "10000"
+	expectedResp.Data.ChargedAmount = "10_000"
 
 	assert.Equal(t, expectedResp.Status, data.Status)
 	assert.Equal(t, expectedResp.Message, data.Message)
@@ -79,7 +79,7 @@ func Test_paymentsService_InitiateMobileMoneyFranco_BadRequest(t *testing.T) {
 
 	// Act
 	_, response, err := client.Payments.InitiateMobileMoneyFranco(ctx, &InitiateMobileMoneyFrancoRequest{
-		Amount:         10_000,
+		Amount:         "10000",
 		Currency:       "XAF",
 		PhoneNumber:    "+237678787878",
 		Email:          "alice@example.com",


### PR DESCRIPTION
This changes the type of the amount values in the InitiateMobileMoneyPayment response from integers to `json.Numbers`. this is because the flutterwave api is not consistent when returning rounded values.
